### PR TITLE
Climber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 }
 
 chopshop {
-    version = "2022.3.1"
+    version = "2022.5.1"
 }
 
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -40,11 +40,14 @@ public class Robot extends CommandRobot {
     copilotController.a().whileHeld(intake.runMechanism(SpinDirection.COUNTERCLOCKWISE));
 
     // Move with variable speed from triggers
-    driveController.x().whileHeld(parallel("Move", leftClimber.move(trigger), rightClimber.move(trigger)));
+    driveController.x().whileHeld(parallel("Move", leftClimber.moveCurrent(trigger), rightClimber.moveCurrent(trigger),
+        leftClimber.moveLimit(trigger), rightClimber.moveLimit(trigger)));
 
     // Button bindings for regular climbing
-    driveController.a().whileHeld(parallel("Extend", leftClimber.extend(), rightClimber.extend()));
-    driveController.b().whileHeld(parallel("Retract", leftClimber.retract(), rightClimber.retract()));
+    driveController.a().whileHeld(parallel("Extend", leftClimber.extendCurrent(), rightClimber.extendCurrent(),
+        leftClimber.extendLimit(), rightClimber.extendLimit()));
+    driveController.b().whileHeld(parallel("Retract", leftClimber.retractCurrent(), rightClimber.retractCurrent(),
+        leftClimber.retractLimit(), rightClimber.retractLimit()));
 
     // Button bindings for ignoring limit switches
     driveController.getPovButton(POVDirection.UP)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -33,21 +33,18 @@ public class Robot extends CommandRobot {
 
   @Override
   public void configureButtonBindings() {
-    driveController.back().whenPressed(drive.resetCmd());
-
     DoubleSupplier trigger = driveController::getTriggers;
+
+    driveController.back().whenPressed(drive.resetCmd());
 
     copilotController.a().whileHeld(intake.runMechanism(SpinDirection.COUNTERCLOCKWISE));
 
     // Move with variable speed from triggers
-    driveController.x().whileHeld(parallel("Move", leftClimber.moveCurrent(trigger), rightClimber.moveCurrent(trigger),
-        leftClimber.moveLimit(trigger), rightClimber.moveLimit(trigger)));
+    driveController.x().whileHeld(parallel("Move", leftClimber.move(trigger), rightClimber.move(trigger)));
 
     // Button bindings for regular climbing
-    driveController.a().whileHeld(parallel("Extend", leftClimber.extendCurrent(), rightClimber.extendCurrent(),
-        leftClimber.extendLimit(), rightClimber.extendLimit()));
-    driveController.b().whileHeld(parallel("Retract", leftClimber.retractCurrent(), rightClimber.retractCurrent(),
-        leftClimber.retractLimit(), rightClimber.retractLimit()));
+    driveController.a().whileHeld(parallel("Extend", leftClimber.extend(), rightClimber.extend()));
+    driveController.b().whileHeld(parallel("Retract", leftClimber.retract(), rightClimber.retract()));
 
     // Button bindings for ignoring limit switches
     driveController.getPovButton(POVDirection.UP)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -40,12 +40,11 @@ public class Robot extends CommandRobot {
     copilotController.a().whileHeld(intake.runMechanism(SpinDirection.COUNTERCLOCKWISE));
 
     // Move with variable speed from triggers
-    driveController.x()
-        .whileHeld(parallel("Move", leftClimber.moveCurrent(trigger), rightClimber.moveCurrent(trigger)));
+    driveController.x().whileHeld(parallel("Move", leftClimber.move(trigger), rightClimber.move(trigger)));
 
     // Button bindings for regular climbing
-    driveController.a().whileHeld(parallel("Extend", leftClimber.extendCurrent(), rightClimber.extendCurrent()));
-    driveController.b().whileHeld(parallel("Retract", leftClimber.retractCurrent(), rightClimber.retractCurrent()));
+    driveController.a().whileHeld(parallel("Extend", leftClimber.extend(), rightClimber.extend()));
+    driveController.b().whileHeld(parallel("Retract", leftClimber.retract(), rightClimber.retract()));
 
     // Button bindings for ignoring limit switches
     driveController.getPovButton(POVDirection.UP)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -40,11 +40,12 @@ public class Robot extends CommandRobot {
     copilotController.a().whileHeld(intake.runMechanism(SpinDirection.COUNTERCLOCKWISE));
 
     // Move with variable speed from triggers
-    driveController.x().whileHeld(parallel("Move", leftClimber.move(trigger), rightClimber.move(trigger)));
+    driveController.x()
+        .whileHeld(parallel("Move", leftClimber.moveCurrent(trigger), rightClimber.moveCurrent(trigger)));
 
     // Button bindings for regular climbing
-    driveController.a().whileHeld(parallel("Extend", leftClimber.extend(), rightClimber.extend()));
-    driveController.b().whileHeld(parallel("Retract", leftClimber.retract(), rightClimber.retract()));
+    driveController.a().whileHeld(parallel("Extend", leftClimber.extendCurrent(), rightClimber.extendCurrent()));
+    driveController.b().whileHeld(parallel("Retract", leftClimber.retractCurrent(), rightClimber.retractCurrent()));
 
     // Button bindings for ignoring limit switches
     driveController.getPovButton(POVDirection.UP)
@@ -63,7 +64,7 @@ public class Robot extends CommandRobot {
 
   @Override
   public void setDefaultCommands() {
-    drive.setDefaultCommand(drive.fieldCentricDrive(driveController::getLeftX,
-        driveController::getLeftY, driveController::getRightX));
+    drive.setDefaultCommand(
+        drive.fieldCentricDrive(driveController::getLeftX, driveController::getLeftY, driveController::getRightX));
   }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,8 +23,8 @@ public class Robot extends CommandRobot {
 
   private final Intake intake = new Intake(map.getIntakeMap());
 
-  private final Climber leftClimber = new Climber(map.getLeftTelescopeMap());
-  private final Climber rightClimber = new Climber(map.getRightTelescopeMap());
+  private final Climber leftClimber = new Climber(map.getLeftClimberMap());
+  private final Climber rightClimber = new Climber(map.getRightClimberMap());
 
   @Override
   public void robotInit() {

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -16,24 +16,8 @@ import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 
 public class GastonMap extends RobotMap {
-    // Climber
-    private final DigitalInput leftUpperLimit = new DigitalInput(0);
-    private final DigitalInput leftLowerLimit = new DigitalInput(1);
-    private final DigitalInput rightUpperLimit = new DigitalInput(2);
-    private final DigitalInput rightLowerLimit = new DigitalInput(3);
-
-    private final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
-    private final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
 
     private final double CLIMBER_CURRENT_LIMIT = 30.0; // The current limit for the climber's motors
-
-    // Intake
-    private final DigitalInput outsideLimit = new DigitalInput(4);
-    private final DigitalInput insideLimit = new DigitalInput(5);
-
-    private final PIDSparkMax deploymentMotor = new PIDSparkMax(2, MotorType.kBrushless);
-    private final PIDSparkMax rollerMotor = new PIDSparkMax(3, MotorType.kBrushless);
-    private final SparkMaxPIDController deploymentPidController = deploymentMotor.getPidController();
 
     @Override
     public SwerveDriveMap getSwerveDriveMap() {
@@ -90,6 +74,12 @@ public class GastonMap extends RobotMap {
 
         // private RelativeEncoder deploymentEncoder =
         // deploymentMotor.getEncoder().getRaw();
+        final DigitalInput outsideLimit = new DigitalInput(4);
+        final DigitalInput insideLimit = new DigitalInput(5);
+
+        final PIDSparkMax deploymentMotor = new PIDSparkMax(2, MotorType.kBrushless);
+        final PIDSparkMax rollerMotor = new PIDSparkMax(3, MotorType.kBrushless);
+        final SparkMaxPIDController deploymentPidController = deploymentMotor.getPidController();
 
         double P = 0;
         double I = 0;
@@ -115,12 +105,18 @@ public class GastonMap extends RobotMap {
     }
 
     public TelescopeMap getLeftTelescopeMap() {
+        final DigitalInput leftUpperLimit = new DigitalInput(0);
+        final DigitalInput leftLowerLimit = new DigitalInput(1);
+        final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
         leftMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
 
         return new TelescopeMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
     }
 
     public TelescopeMap getRightTelescopeMap() {
+        final DigitalInput rightUpperLimit = new DigitalInput(2);
+        final DigitalInput rightLowerLimit = new DigitalInput(3);
+        final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
         rightMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
 
         return new TelescopeMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -74,8 +74,8 @@ public class GastonMap extends RobotMap {
 
         // private RelativeEncoder deploymentEncoder =
         // deploymentMotor.getEncoder().getRaw();
-        final DigitalInput outsideLimit = new DigitalInput(6);
-        final DigitalInput insideLimit = new DigitalInput(7);
+        final DigitalInput outsideLimit = new DigitalInput(5);
+        final DigitalInput insideLimit = new DigitalInput(6);
 
         final PIDSparkMax deploymentMotor = new PIDSparkMax(11, MotorType.kBrushless);
         final PIDSparkMax rollerMotor = new PIDSparkMax(12, MotorType.kBrushless);

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -16,6 +16,25 @@ import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
 
 public class GastonMap extends RobotMap {
+    // Climber
+    private final DigitalInput leftUpperLimit = new DigitalInput(0);
+    private final DigitalInput leftLowerLimit = new DigitalInput(1);
+    private final DigitalInput rightUpperLimit = new DigitalInput(2);
+    private final DigitalInput rightLowerLimit = new DigitalInput(3);
+
+    private final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
+    private final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
+
+    private final double CLIMBER_CURRENT_LIMIT = 30.0; // The current limit for the climber's motors
+
+    // Intake
+    private final DigitalInput outsideLimit = new DigitalInput(4);
+    private final DigitalInput insideLimit = new DigitalInput(5);
+
+    private final PIDSparkMax deploymentMotor = new PIDSparkMax(2, MotorType.kBrushless);
+    private final PIDSparkMax rollerMotor = new PIDSparkMax(3, MotorType.kBrushless);
+    private final SparkMaxPIDController deploymentPidController = deploymentMotor.getPidController();
+
     @Override
     public SwerveDriveMap getSwerveDriveMap() {
         // Value taken from CAD as offset from center of module base pulley to center of
@@ -27,40 +46,32 @@ public class GastonMap extends RobotMap {
         final CANCoder encoderFL = new CANCoder(1);
         encoderFL.configMagnetOffset(0); // TODO Get Magnet Offset
         encoderFL.configAbsoluteSensorRange(AbsoluteSensorRange.Unsigned_0_to_360);
-        final SDSSwerveModule frontLeft = new SDSSwerveModule(
-                new Translation2d(MODULE_OFFSET_XY, MODULE_OFFSET_XY),
-                encoderFL,
-                new PIDSparkMax(2, MotorType.kBrushless), new PIDSparkMax(1, MotorType.kBrushless),
+        final SDSSwerveModule frontLeft = new SDSSwerveModule(new Translation2d(MODULE_OFFSET_XY, MODULE_OFFSET_XY),
+                encoderFL, new PIDSparkMax(2, MotorType.kBrushless), new PIDSparkMax(1, MotorType.kBrushless),
                 SDSSwerveModule.MK4_V2);
 
         // Front Right Module
         final CANCoder encoderFR = new CANCoder(2);
         encoderFR.configMagnetOffset(0); // TODO Get Magnet Offset
         encoderFR.configAbsoluteSensorRange(AbsoluteSensorRange.Unsigned_0_to_360);
-        final SDSSwerveModule frontRight = new SDSSwerveModule(
-                new Translation2d(MODULE_OFFSET_XY, -MODULE_OFFSET_XY),
-                encoderFR,
-                new PIDSparkMax(4, MotorType.kBrushless), new PIDSparkMax(3, MotorType.kBrushless),
+        final SDSSwerveModule frontRight = new SDSSwerveModule(new Translation2d(MODULE_OFFSET_XY, -MODULE_OFFSET_XY),
+                encoderFR, new PIDSparkMax(4, MotorType.kBrushless), new PIDSparkMax(3, MotorType.kBrushless),
                 SDSSwerveModule.MK4_V2);
 
         // Rear Left Module
         final CANCoder encoderRL = new CANCoder(3);
         encoderRL.configMagnetOffset(0); // TODO Get Magnet Offset
         encoderRL.configAbsoluteSensorRange(AbsoluteSensorRange.Unsigned_0_to_360);
-        final SDSSwerveModule rearLeft = new SDSSwerveModule(
-                new Translation2d(-MODULE_OFFSET_XY, MODULE_OFFSET_XY),
-                encoderRL,
-                new PIDSparkMax(6, MotorType.kBrushless), new PIDSparkMax(5, MotorType.kBrushless),
+        final SDSSwerveModule rearLeft = new SDSSwerveModule(new Translation2d(-MODULE_OFFSET_XY, MODULE_OFFSET_XY),
+                encoderRL, new PIDSparkMax(6, MotorType.kBrushless), new PIDSparkMax(5, MotorType.kBrushless),
                 SDSSwerveModule.MK4_V2);
 
         // Rear Right Module
         final CANCoder encoderRR = new CANCoder(4);
         encoderRR.configMagnetOffset(0); // TODO Get Magnet Offset
         encoderRR.configAbsoluteSensorRange(AbsoluteSensorRange.Unsigned_0_to_360);
-        final SDSSwerveModule rearRight = new SDSSwerveModule(
-                new Translation2d(-MODULE_OFFSET_XY, -MODULE_OFFSET_XY),
-                encoderRR,
-                new PIDSparkMax(8, MotorType.kBrushless), new PIDSparkMax(7, MotorType.kBrushless),
+        final SDSSwerveModule rearRight = new SDSSwerveModule(new Translation2d(-MODULE_OFFSET_XY, -MODULE_OFFSET_XY),
+                encoderRR, new PIDSparkMax(8, MotorType.kBrushless), new PIDSparkMax(7, MotorType.kBrushless),
                 SDSSwerveModule.MK4_V2);
 
         final double maxDriveSpeedMetersPerSecond = Units.feetToMeters(10);
@@ -72,24 +83,6 @@ public class GastonMap extends RobotMap {
         return new SwerveDriveMap(frontLeft, frontRight, rearLeft, rearRight, maxDriveSpeedMetersPerSecond,
                 maxRotationRadianPerSecond, gyro);
     }
-
-    // These are outsied the methods to prevent resource leaks
-    // climber stuff
-    private final DigitalInput leftUpperLimit = new DigitalInput(0);
-    private final DigitalInput leftLowerLimit = new DigitalInput(1);
-    private final DigitalInput rightUpperLimit = new DigitalInput(2);
-    private final DigitalInput rightLowerLimit = new DigitalInput(3);
-
-    private final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
-    private final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
-
-    // intake stuff
-    private final DigitalInput outsideLimit = new DigitalInput(4);
-    private final DigitalInput insideLimit = new DigitalInput(5);
-
-    private final PIDSparkMax deploymentMotor = new PIDSparkMax(2, MotorType.kBrushless);
-    private final PIDSparkMax rollerMotor = new PIDSparkMax(3, MotorType.kBrushless);
-    private final SparkMaxPIDController deploymentPidController = deploymentMotor.getPidController();
 
     public IntakeMap getIntakeMap() {
         // PID coefficients
@@ -122,10 +115,18 @@ public class GastonMap extends RobotMap {
     }
 
     public TelescopeMap getLeftTelescopeMap() {
-        return new TelescopeMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
+        leftMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
+        // Uncomment if limit switches are used
+        // leftMotor.addValidator(() -> !leftUpperLimit.getAsBoolean());
+        // leftMotor.addValidator(() -> !leftLowerLimit.getAsBoolean());
+        return new TelescopeMap(leftMotor);
     }
 
     public TelescopeMap getRightTelescopeMap() {
-        return new TelescopeMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);
+        rightMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
+        // Uncomment if limit switches are used
+        // leftMotor.addValidator(() -> !rightUpperLimit.getAsBoolean());
+        // leftMotor.addValidator(() -> !rightLowerLimit.getAsBoolean());
+        return new TelescopeMap(rightMotor);
     }
 }

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -116,17 +116,13 @@ public class GastonMap extends RobotMap {
 
     public TelescopeMap getLeftTelescopeMap() {
         leftMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
-        // Uncomment if limit switches are used
-        // leftMotor.addValidator(() -> !leftUpperLimit.getAsBoolean());
-        // leftMotor.addValidator(() -> !leftLowerLimit.getAsBoolean());
-        return new TelescopeMap(leftMotor);
+
+        return new TelescopeMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
     }
 
     public TelescopeMap getRightTelescopeMap() {
         rightMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
-        // Uncomment if limit switches are used
-        // leftMotor.addValidator(() -> !rightUpperLimit.getAsBoolean());
-        // leftMotor.addValidator(() -> !rightLowerLimit.getAsBoolean());
-        return new TelescopeMap(rightMotor);
+
+        return new TelescopeMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);
     }
 }

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -74,11 +74,11 @@ public class GastonMap extends RobotMap {
 
         // private RelativeEncoder deploymentEncoder =
         // deploymentMotor.getEncoder().getRaw();
-        final DigitalInput outsideLimit = new DigitalInput(4);
-        final DigitalInput insideLimit = new DigitalInput(5);
+        final DigitalInput outsideLimit = new DigitalInput(6);
+        final DigitalInput insideLimit = new DigitalInput(7);
 
-        final PIDSparkMax deploymentMotor = new PIDSparkMax(2, MotorType.kBrushless);
-        final PIDSparkMax rollerMotor = new PIDSparkMax(3, MotorType.kBrushless);
+        final PIDSparkMax deploymentMotor = new PIDSparkMax(11, MotorType.kBrushless);
+        final PIDSparkMax rollerMotor = new PIDSparkMax(12, MotorType.kBrushless);
         final SparkMaxPIDController deploymentPidController = deploymentMotor.getPidController();
 
         double P = 0;
@@ -105,18 +105,17 @@ public class GastonMap extends RobotMap {
     }
 
     public ClimberMap getLeftClimberMap() {
-        final DigitalInput leftUpperLimit = new DigitalInput(0);
-        final DigitalInput leftLowerLimit = new DigitalInput(1);
-        final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
+        final DigitalInput leftUpperLimit = new DigitalInput(1);
+        final DigitalInput leftLowerLimit = new DigitalInput(2);
+        final PIDSparkMax leftMotor = new PIDSparkMax(9, MotorType.kBrushless);
         leftMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
-
         return new ClimberMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
     }
 
     public ClimberMap getRightTelescopeMap() {
-        final DigitalInput rightUpperLimit = new DigitalInput(2);
-        final DigitalInput rightLowerLimit = new DigitalInput(3);
-        final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
+        final DigitalInput rightUpperLimit = new DigitalInput(3);
+        final DigitalInput rightLowerLimit = new DigitalInput(4);
+        final PIDSparkMax rightMotor = new PIDSparkMax(10, MotorType.kBrushless);
         rightMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
 
         return new ClimberMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);

--- a/src/main/java/frc/robot/maps/GastonMap.java
+++ b/src/main/java/frc/robot/maps/GastonMap.java
@@ -104,21 +104,21 @@ public class GastonMap extends RobotMap {
 
     }
 
-    public TelescopeMap getLeftTelescopeMap() {
+    public ClimberMap getLeftClimberMap() {
         final DigitalInput leftUpperLimit = new DigitalInput(0);
         final DigitalInput leftLowerLimit = new DigitalInput(1);
         final PIDSparkMax leftMotor = new PIDSparkMax(0, MotorType.kBrushless);
         leftMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
 
-        return new TelescopeMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
+        return new ClimberMap(leftMotor, leftUpperLimit::get, leftLowerLimit::get);
     }
 
-    public TelescopeMap getRightTelescopeMap() {
+    public ClimberMap getRightTelescopeMap() {
         final DigitalInput rightUpperLimit = new DigitalInput(2);
         final DigitalInput rightLowerLimit = new DigitalInput(3);
         final PIDSparkMax rightMotor = new PIDSparkMax(1, MotorType.kBrushless);
         rightMotor.validateCurrent(CLIMBER_CURRENT_LIMIT);
 
-        return new TelescopeMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);
+        return new ClimberMap(rightMotor, rightUpperLimit::get, rightLowerLimit::get);
     }
 }

--- a/src/main/java/frc/robot/maps/RobotMap.java
+++ b/src/main/java/frc/robot/maps/RobotMap.java
@@ -138,29 +138,17 @@ public class RobotMap {
 
     public static class TelescopeMap {
         private final SmartMotorController motor;
-        private final BooleanSupplier upperLimit;
-        private final BooleanSupplier lowerLimit;
 
-        public TelescopeMap(SmartMotorController motor, BooleanSupplier upperLimit, BooleanSupplier lowerLimit) {
+        public TelescopeMap(SmartMotorController motor) {
             this.motor = motor;
-            this.upperLimit = upperLimit;
-            this.lowerLimit = lowerLimit;
         }
 
         public TelescopeMap() {
-            this(new SmartMotorController(), new MockDigitalInput(), new MockDigitalInput());
+            this(new SmartMotorController(new SmartMotorController()));
         }
 
         public SmartMotorController getMotor() {
             return motor;
-        }
-
-        public BooleanSupplier getUpperLimit() {
-            return upperLimit;
-        }
-
-        public BooleanSupplier getLowerLimit() {
-            return lowerLimit;
         }
 
     }

--- a/src/main/java/frc/robot/maps/RobotMap.java
+++ b/src/main/java/frc/robot/maps/RobotMap.java
@@ -138,17 +138,30 @@ public class RobotMap {
 
     public static class TelescopeMap {
         private final SmartMotorController motor;
+        private final BooleanSupplier upperLimit;
+        private final BooleanSupplier lowerLimit;
 
-        public TelescopeMap(SmartMotorController motor) {
+        public TelescopeMap(SmartMotorController motor, BooleanSupplier upperLimit, BooleanSupplier lowerLimit) {
             this.motor = motor;
+            this.upperLimit = upperLimit;
+            this.lowerLimit = lowerLimit;
+
         }
 
         public TelescopeMap() {
-            this(new SmartMotorController(new SmartMotorController()));
+            this(new SmartMotorController(new SmartMotorController()), new MockDigitalInput(), new MockDigitalInput());
         }
 
         public SmartMotorController getMotor() {
             return motor;
+        }
+
+        public BooleanSupplier getUpperLimit() {
+            return upperLimit;
+        }
+
+        public BooleanSupplier getLowerLimit() {
+            return lowerLimit;
         }
 
     }

--- a/src/main/java/frc/robot/maps/RobotMap.java
+++ b/src/main/java/frc/robot/maps/RobotMap.java
@@ -149,7 +149,7 @@ public class RobotMap {
         }
 
         public TelescopeMap() {
-            this(new SmartMotorController(new SmartMotorController()), new MockDigitalInput(), new MockDigitalInput());
+            this(new SmartMotorController(), new MockDigitalInput(), new MockDigitalInput());
         }
 
         public SmartMotorController getMotor() {

--- a/src/main/java/frc/robot/maps/RobotMap.java
+++ b/src/main/java/frc/robot/maps/RobotMap.java
@@ -136,19 +136,19 @@ public class RobotMap {
         }
     }
 
-    public static class TelescopeMap {
+    public static class ClimberMap {
         private final SmartMotorController motor;
         private final BooleanSupplier upperLimit;
         private final BooleanSupplier lowerLimit;
 
-        public TelescopeMap(SmartMotorController motor, BooleanSupplier upperLimit, BooleanSupplier lowerLimit) {
+        public ClimberMap(SmartMotorController motor, BooleanSupplier upperLimit, BooleanSupplier lowerLimit) {
             this.motor = motor;
             this.upperLimit = upperLimit;
             this.lowerLimit = lowerLimit;
 
         }
 
-        public TelescopeMap() {
+        public ClimberMap() {
             this(new SmartMotorController(), new MockDigitalInput(), new MockDigitalInput());
         }
 
@@ -170,11 +170,11 @@ public class RobotMap {
         return new IntakeMap();
     }
 
-    public TelescopeMap getLeftTelescopeMap() {
-        return new TelescopeMap();
+    public ClimberMap getLeftClimberMap() {
+        return new ClimberMap();
     }
 
-    public TelescopeMap getRightTelescopeMap() {
-        return new TelescopeMap();
+    public ClimberMap getRightClimberMap() {
+        return new ClimberMap();
     }
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -30,8 +30,8 @@ public class Climber extends SmartSubsystemBase {
   }
 
   // Move the motor based on a variable speed and stop when validator fails
-  public CommandBase move(DoubleSupplier speed) {
-    return cmd("Move").onExecute(() -> {
+  public CommandBase moveCurrent(DoubleSupplier speed) {
+    return cmd("Move With Current Limit").onExecute(() -> {
       motor.set(validatorLimit.applyAsDouble(speed.getAsDouble()));
       SmartDashboard.putNumber("Climber Speed", speed.getAsDouble());
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
@@ -49,8 +49,8 @@ public class Climber extends SmartSubsystemBase {
   }
 
   // Extend the climber and use validators stop the motors
-  public CommandBase extend() {
-    return cmd("Extend").onExecute(() -> {
+  public CommandBase extendCurrent() {
+    return cmd("Extend With Current Limit").onExecute(() -> {
       motor.set(validatorLimit.applyAsDouble(EXTEND_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
       motor.set(0.0);
@@ -66,8 +66,8 @@ public class Climber extends SmartSubsystemBase {
     });
   }
 
-  public CommandBase retract() {
-    return cmd("Extend").onExecute(() -> {
+  public CommandBase retractCurrent() {
+    return cmd("Retract With Current Limit").onExecute(() -> {
       motor.set(validatorLimit.applyAsDouble(RETRACT_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
       motor.set(0.0);

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -20,8 +20,6 @@ public class Climber extends SmartSubsystemBase {
   private final double RETRACT_SPEED = -1.0;
 
   private final SmartMotorController motor;
-  private final BooleanSupplier upperLimit;
-  private final BooleanSupplier lowerLimit;
 
   private final Modifier limit;
 
@@ -30,8 +28,6 @@ public class Climber extends SmartSubsystemBase {
 
     limit = Modifier.unless(motor::errored);
   }
-
-  /
 
   // Move the motor based on a variable speed and stop when limit switches are hit
   public CommandBase move(DoubleSupplier speed) {

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -31,8 +31,7 @@ public class Climber extends SmartSubsystemBase {
 
   // Move the motor based on a variable speed and stop when limit switches are hit
   public CommandBase move(DoubleSupplier speed) {
-    return cmd("Move").onInitialize(() -> {
-    }).onExecute(() -> {
+    return cmd("Move").onExecute(() -> {
       motor.set(limit.applyAsDouble(speed.getAsDouble()));
       SmartDashboard.putNumber("Climber Speed", speed.getAsDouble());
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
@@ -42,8 +41,7 @@ public class Climber extends SmartSubsystemBase {
 
   // Extend the climber and use validators stop the motors
   public CommandBase extend() {
-    return cmd("Extend").onInitialize(() -> {
-    }).onExecute(() -> {
+    return cmd("Extend").onExecute(() -> {
       motor.set(limit.applyAsDouble(EXTEND_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
       motor.set(0.0);
@@ -51,8 +49,7 @@ public class Climber extends SmartSubsystemBase {
   }
 
   public CommandBase retract() {
-    return cmd("Extend").onInitialize(() -> {
-    }).onExecute(() -> {
+    return cmd("Extend").onExecute(() -> {
       motor.set(limit.applyAsDouble(RETRACT_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
       motor.set(0.0);

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -1,12 +1,10 @@
 package frc.robot.subsystems;
 
-import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 import com.chopshop166.chopshoplib.commands.SmartSubsystemBase;
 import com.chopshop166.chopshoplib.motors.Modifier;
 import com.chopshop166.chopshoplib.motors.ModifierGroup;
-import com.chopshop166.chopshoplib.motors.PIDSparkMax;
 import com.chopshop166.chopshoplib.motors.SmartMotorController;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -21,20 +19,31 @@ public class Climber extends SmartSubsystemBase {
 
   private final SmartMotorController motor;
 
-  private final Modifier limit;
+  private final Modifier validatorLimit;
+  private final ModifierGroup switchLimit;
 
   public Climber(TelescopeMap map) {
     motor = map.getMotor();
+    switchLimit = new ModifierGroup(Modifier.upperLimit(map.getUpperLimit()), Modifier.lowerLimit(map.getLowerLimit()));
 
-    limit = Modifier.unless(motor::errored);
+    validatorLimit = Modifier.unless(motor::errored);
   }
 
-  // Move the motor based on a variable speed and stop when limit switches are hit
+  // Move the motor based on a variable speed and stop when validator fails
   public CommandBase move(DoubleSupplier speed) {
     return cmd("Move").onExecute(() -> {
-      motor.set(limit.applyAsDouble(speed.getAsDouble()));
+      motor.set(validatorLimit.applyAsDouble(speed.getAsDouble()));
       SmartDashboard.putNumber("Climber Speed", speed.getAsDouble());
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
+      motor.set(0.0);
+    });
+  }
+
+  // Move the motor with variable speed and stop when limit switches are hit
+  public CommandBase moveLimit(DoubleSupplier speed) {
+    return cmd("Move With Limits").onExecute(() -> {
+      motor.set(switchLimit.run(speed.getAsDouble()));
+    }).onEnd((interrupted) -> {
       motor.set(0.0);
     });
   }
@@ -42,16 +51,34 @@ public class Climber extends SmartSubsystemBase {
   // Extend the climber and use validators stop the motors
   public CommandBase extend() {
     return cmd("Extend").onExecute(() -> {
-      motor.set(limit.applyAsDouble(EXTEND_SPEED));
+      motor.set(validatorLimit.applyAsDouble(EXTEND_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
+      motor.set(0.0);
+    });
+  }
+
+  // Extend the motor with limit switches
+  public CommandBase extendLimit() {
+    return cmd("Extend With Limits").onExecute(() -> {
+      motor.set(switchLimit.run(EXTEND_SPEED));
+    }).onEnd((interrupted) -> {
       motor.set(0.0);
     });
   }
 
   public CommandBase retract() {
     return cmd("Extend").onExecute(() -> {
-      motor.set(limit.applyAsDouble(RETRACT_SPEED));
+      motor.set(validatorLimit.applyAsDouble(RETRACT_SPEED));
     }).finishedWhen(motor::errored).onEnd((interrupted) -> {
+      motor.set(0.0);
+    });
+  }
+
+  // Retract the motor with limit switches
+  public CommandBase retractLimit() {
+    return cmd("Retract With Limits").onExecute(() -> {
+      motor.set(switchLimit.run(RETRACT_SPEED));
+    }).onEnd((interrupted) -> {
       motor.set(0.0);
     });
   }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -28,9 +28,9 @@ public class Climber extends SmartSubsystemBase {
     Modifier upperLimit = Modifier.upperLimit(map.getUpperLimit());
     Modifier lowerLimit = Modifier.lowerLimit(map.getLowerLimit());
     motor = map.getMotor();
-    switchLimit = new ModifierGroup(upperLimit , lowerLimit);
+    switchLimit = new ModifierGroup(upperLimit, lowerLimit);
     validatorLimit = Modifier.unless(motor::errored);
-    limit = new ModifierGroup(upperLimit, lowerLimit, validatorLimit)
+    limit = new ModifierGroup(upperLimit, lowerLimit, validatorLimit);
   }
 
   // Move the motor based off a variable speed

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -1,6 +1,5 @@
 package frc.robot.subsystems;
 
-import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 import com.chopshop166.chopshoplib.commands.SmartSubsystemBase;

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -36,6 +36,7 @@ public class Climber extends SmartSubsystemBase {
   public CommandBase move(DoubleSupplier speed) {
     return cmd("Move").onExecute(() -> {
       motor.set(limit.run(speed.getAsDouble()));
+      SmartDashboard.putNumber("Climber Speed", speed.getAsDouble());
     }).onEnd((interrupted) -> {
       motor.set(0.0);
     });
@@ -55,6 +56,7 @@ public class Climber extends SmartSubsystemBase {
   public CommandBase moveLimit(DoubleSupplier speed) {
     return cmd("Move With Limits").onExecute(() -> {
       motor.set(switchLimit.run(speed.getAsDouble()));
+      SmartDashboard.putNumber("Climber Speed", speed.getAsDouble());
     }).onEnd((interrupted) -> {
       motor.set(0.0);
     });

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -9,7 +9,7 @@ import com.chopshop166.chopshoplib.motors.SmartMotorController;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.maps.RobotMap.TelescopeMap;
+import frc.robot.maps.RobotMap.ClimberMap;
 
 public class Climber extends SmartSubsystemBase {
 
@@ -23,7 +23,7 @@ public class Climber extends SmartSubsystemBase {
   private final ModifierGroup switchLimit;
   private final ModifierGroup limit;
 
-  public Climber(TelescopeMap map) {
+  public Climber(ClimberMap map) {
     Modifier upperLimit = Modifier.upperLimit(map.getUpperLimit());
     Modifier lowerLimit = Modifier.lowerLimit(map.getLowerLimit());
     motor = map.getMotor();

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -6,6 +6,7 @@ import java.util.function.DoubleSupplier;
 import com.chopshop166.chopshoplib.commands.SmartSubsystemBase;
 import com.chopshop166.chopshoplib.motors.Modifier;
 import com.chopshop166.chopshoplib.motors.ModifierGroup;
+import com.chopshop166.chopshoplib.motors.PIDSparkMax;
 import com.chopshop166.chopshoplib.motors.SmartMotorController;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -17,6 +18,7 @@ public class Climber extends SmartSubsystemBase {
   // Constants:
   private final double EXTEND_SPEED = 1.0;
   private final double RETRACT_SPEED = -1.0;
+  private final double CURRENT_LIMIT = 1.0; // Current limit in amps, motor stops when this is reached
 
   private final SmartMotorController motor;
   private final BooleanSupplier upperLimit;
@@ -43,6 +45,22 @@ public class Climber extends SmartSubsystemBase {
     }).onEnd((interrupted) -> {
       motor.set(0.0);
     });
+  }
+
+  public CommandBase extendCurrent() {
+    return cmd("Extend With Current Limits").onInitialize(() -> {
+      motor.set(EXTEND_SPEED);
+    }).finishedWhen(() -> ((PIDSparkMax) motor).getMotorController().getOutputCurrent() >= CURRENT_LIMIT)
+        .onEnd((interrupted) -> {
+        });
+  }
+
+  public CommandBase retractCurrent() {
+    return cmd("Retract With Current Limits").onInitialize(() -> {
+      motor.set(RETRACT_SPEED);
+    }).finishedWhen(() -> ((PIDSparkMax) motor).getMotorController().getOutputCurrent() >= CURRENT_LIMIT)
+        .onEnd((interrupted) -> {
+        });
   }
 
   public CommandBase extend() {


### PR DESCRIPTION
Implement current limits into the Climber subsystem which measures the motors' current and uses that value to stop the motors instead of using limit switches. Three new commands are added: extendCurrent, retractCurrent, and moveCurrent, which implement this new functionality.